### PR TITLE
[2021.02.02] Added basis_funcs.py.

### DIFF
--- a/MuJoCo/modules/basis_funcs.py
+++ b/MuJoCo/modules/basis_funcs.py
@@ -1,0 +1,40 @@
+# [Built-in modules]
+import os
+import re
+import sys
+import shutil
+import time, datetime
+import math  as myMath
+
+# [3rd party modules]
+import numpy as np
+import sympy as sp
+from sympy.utilities.lambdify import lambdify, implemented_function
+from modules.constants import Constants
+
+"""
+    This python script defines the basis functions/miscellaneous functions that will be used for multiple situations
+
+"""
+
+def min_jerk_traj( t, pi, pf, D ):
+    """
+        Description:
+        ----------
+            The lambda function for the minimum-jerk-trajectory, suggested by Prof. Hogan.
+            It is a 5-th order polynomial which minimizes the mean-squared-jerk value.
+            [REF] Flash, Tamar, and Neville Hogan. "The coordination of arm movements: an experimentally confirmed mathematical model." Journal of neuroscience 5.7 (1985): 1688-1703.
+
+        Arguments:
+        ----------
+            [1]  t: (sym)   The time symbol
+            [2] pi: (array) Initial posture
+            [3] pf: (array)   Final posture
+            [4]  D: (float) Duration it took from start to end
+
+        Returns:
+        ----------
+            Function w.r.t. t function of the min_jerk_trajectory
+    """
+
+    return pi + ( pf - pi ) * ( 10 * np.power( t ,3 ) / ( D ** 3 ) - 15 * np.power( t , 4 ) / ( D ** 4 ) +  6 * np.power( t, 5 ) / ( D ** 5 ) )

--- a/MuJoCo/modules/controllers.py
+++ b/MuJoCo/modules/controllers.py
@@ -5,7 +5,8 @@ import numpy as np
 import time
 import pickle
 
-from modules.utils        import my_print
+from   modules.utils        import my_print
+from   modules.basis_funcs  import min_jerk_traj
 import matplotlib.pyplot as plt
 
 try:
@@ -93,7 +94,6 @@ class ImpedanceController( Controller ):
         self.ZFT_func_pos   = None
         self.ZFT_func_vel   = None
 
-
         # Mass information of the limbs
         if self.n_limbs == 2:                                                   # For arm model with 2 limbs.
             bodyName  = ['upperArm', 'foreArm' ]                                # Masses of the body that are needed for the gravity compensation
@@ -153,7 +153,6 @@ class ImpedanceController( Controller ):
         self.ctrl_par_names = [ "mov_parameters", "K", "B" ]                    # Useful for self.set_ctrl_par method
         self.t_sym = sp.symbols( 't' )                                          # time symbol of the equation
 
-
     def gravity_compensation( self ):
 
         if self.is_grav_comps:
@@ -195,7 +194,7 @@ class ImpedanceController( Controller ):
         # Basis function used for the ZFT Trajectory is minimum-jerk-trajectory
         # [REF] [Moses C. Nah] [MIT Master's Thesis]: "Dynamic Primitives Facilitate Manipulating a Whip", [Section 7.2.2.] Zero-torque trajectory
         # [REF] [T. Flash and N. Hogan]             : "Flash, Tamar, and Neville Hogan. "The coordination of arm movements: an experimentally confirmed mathematical model."
-        self.ZFT_func_pos = pi + ( pf - pi ) * ( 10 * np.power( self.t_sym ,3 ) / ( D ** 3 ) - 15 * np.power( self.t_sym , 4 ) / ( D ** 4 ) +  6 * np.power( self.t_sym , 5 ) / ( D ** 5 ) )
+        self.ZFT_func_pos = min_jerk_traj( self.t_sym, pi, pf, D )
         self.ZFT_func_vel = [ sp.diff( tmp, self.t_sym ) for tmp in self.ZFT_func_pos ]
 
         # Lambdify the functions


### PR DESCRIPTION
* Since the minimum-jerk-trajectory is often used as a basis function, and the single-line code is sort of long, we simply added a python script `basis_funcs.py`, which will contain these often-used basis functions + miscellaneous functions for future usages.